### PR TITLE
Rename test_lint to test_tflint

### DIFF
--- a/{{cookiecutter.name}}/makefile
+++ b/{{cookiecutter.name}}/makefile
@@ -43,7 +43,7 @@ all:
 
 chores: documentation formatting
 
-test: test_documentation test_lint test_security test_validation test_formatting
+test: test_documentation test_tflint test_security test_validation test_formatting
 
 #
 # Install


### PR DESCRIPTION
Small fix to rename `test_lint` to `test_tflint` in the Makefile, because when running `make test` it currently fails with `No rule to make target `test_lint'`